### PR TITLE
Use inheritance instead of wrapping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 py-environ: ConfigParser with environmental override
 ====================================================
 
-This is a ConfigParser wrapper that uses an underlying ConfigParser to
-load and parse configuration with the ability to override option
-values from the environment.
+This is a ConfigParser implementation that forwards to
+SafeConfigParser to load and parse configuration, while allowing
+option values to be overriden from the environment.
 
 
 Usage
@@ -11,8 +11,8 @@ Usage
 ```
     from py_environ import EnvironmentConfigWrapper
 
-    # Create a wrapper around a config parser
-    config = EnvironmentConfigWrapper(SafeConfigParser())
+    # Create a config parser
+    config = EnvironmentConfigWrapper()
     
     # Use as is
     option_one_str = config.get('My Section', 'option_one')

--- a/py_environ.py
+++ b/py_environ.py
@@ -17,28 +17,7 @@ def to_environ_key(k):
             .replace(':', '_') \
 
 
-class EnvironmentConfigWrapper(object):
-    def __init__(self, config_parser):
-        if config_parser is None:
-            raise ValueError("Must pass a ConfigParser to wrap")
-
-        self.config_parser = config_parser
-
-    def defaults(self):
-        return self.config_parser.defaults()
-
-    def sections(self):
-        return self.config_parser.sections()
-
-    def add_section(self, section):
-        return self.config_parser.add_section(section)
-
-    def set(self, section, option, value):
-        return self.config_parser.set(section, option, value)
-
-    def remove_option(self, section, option):
-        return self.config_parser.remove_option(section, option)
-
+class EnvironmentConfigWrapper(SafeConfigParser, object):
     def has_option(self, section, option):
         env_prefix = to_environ_key(section)
         env_option = to_environ_key(option)
@@ -47,7 +26,7 @@ class EnvironmentConfigWrapper(object):
         if env_name in os.environ:
             return True
         else:
-            return self.config_parser.has_option(section, option)
+            return super(EnvironmentConfigWrapper, self).has_option(section, option)
 
     def get(self, section, option):
         env_prefix = to_environ_key(section)
@@ -57,26 +36,5 @@ class EnvironmentConfigWrapper(object):
         if env_name in os.environ:
             return os.environ[env_name]
         else:
-            return self.config_parser.get(section, option)
-
-    def getint(self, section, option):
-        v = self.get(section, option)
-        log.debug("get (to int): %s, %s => %s", section, option, v)
-        return int(v)
-
-    def getfloat(self, section, option):
-        v = self.get(section, option)
-        log.debug("get (to float): %s, %s => %s", section, option, v)
-        return float(v)
-
-    def getboolean(self, section, option):
-        v = self.get(section, option)
-        log.debug("get (to bool): %s, %s => %s", section, option, v)
-
-        if v.lower() in TRUE_EQUIVALENT_STRINGS:
-            return True
-        elif v.lower() in FALSE_EQUIVALENT_STRINGS:
-            return False
-        else:
-            raise ValueError(v)
+            return super(EnvironmentConfigWrapper, self).get(section, option)
         

--- a/py_environ_test.py
+++ b/py_environ_test.py
@@ -13,7 +13,7 @@ def test_to_environ_key():
 @mock.patch.dict(os.environ, {'SECTION1_VAR_ONE': 'foo',
                               'SECTION2_VAR_TWO': 'bar'})
 def test_wrapper_get():
-    config = EnvironmentConfigWrapper(SafeConfigParser())
+    config = EnvironmentConfigWrapper()
     config.add_section('Section1')
     config.add_section('Section2')
 
@@ -32,7 +32,7 @@ def test_wrapper_get():
                               'SECTION3_FLOAT_VAR2': '0.4',
                               'SECTION3_SHOULD_FOO': 'False'})
 def test_wrapper_get_type_coercion():
-    config = EnvironmentConfigWrapper(SafeConfigParser())
+    config = EnvironmentConfigWrapper()
     config.add_section('Section1')
     config.add_section('Section2')
     config.add_section('Section3')


### PR DESCRIPTION
Make `EnvironmentConfigWrapper` a true subclass of SafeConfigParser, delegating to super() for the rest of the implementation, removing the extraneous (and possibly buggy) type conversion methods.
